### PR TITLE
[BACKPORT] SystemUI: Fix alignment glitch with brightness mirror

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
@@ -81,6 +81,7 @@ public class QSPanel extends LinearLayout implements Tunable, Callback {
     private Record mDetailRecord;
 
     private BrightnessMirrorController mBrightnessMirrorController;
+    private ImageView mMirrorAutoBrightnessView;
 
     public QSPanel(Context context) {
         this(context, null);
@@ -158,6 +159,10 @@ public class QSPanel extends LinearLayout implements Tunable, Callback {
         } else if (QS_SHOW_AUTO_BRIGHTNESS.equals(key) && mIsAutomaticBrightnessAvailable) {
             mAutoBrightnessView.setVisibility(newValue == null || Integer.parseInt(newValue) != 0
                     ? VISIBLE : GONE);
+            if (mMirrorAutoBrightnessView != null) {
+                mMirrorAutoBrightnessView.setVisibility(newValue == null ||
+                        Integer.parseInt(newValue) != 0 ? INVISIBLE : GONE);
+            }
         }
     }
 
@@ -179,6 +184,9 @@ public class QSPanel extends LinearLayout implements Tunable, Callback {
         mBrightnessMirrorController = c;
         ToggleSlider brightnessSlider = (ToggleSlider) findViewById(R.id.brightness_slider);
         ToggleSlider mirror = (ToggleSlider) c.getMirror().findViewById(R.id.brightness_slider);
+        mMirrorAutoBrightnessView = (ImageView) c.getMirror().findViewById(R.id.brightness_icon);
+        mMirrorAutoBrightnessView.setVisibility(mAutoBrightnessView.getVisibility()
+                    == View.VISIBLE ? View.INVISIBLE : View.GONE);
         brightnessSlider.setMirror(mirror);
         brightnessSlider.setMirrorController(c);
     }


### PR DESCRIPTION
Alignment of brightness mirror dialog was not exatly same as the
QS brightness dialog, which produced a visual glitch of slider
thumb shifting whenever we change brightness.
This is solved by dynamically handling the visibility of
mirror brightness icon, gone when brightness icon is off and
invisible when brightness icon is on, so that both mirror and
QS slider are equally aligned.

Change-Id: Ifb85643db669ee8d7473d3c48e7e4733428a77d6