### PR TITLE
keyguard: Handle left icon visibility properly with wifi only devices

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBottomAreaView.java
@@ -362,8 +362,10 @@ public class KeyguardBottomAreaView extends FrameLayout implements View.OnClickL
         if (visible) {
             if (isTargetCustom(Shortcuts.LEFT_SHORTCUT)) {
                 visible = !mShortcutHelper.isTargetEmpty(Shortcuts.LEFT_SHORTCUT);
-            } else {
+            } else if (canLaunchVoiceAssist()) {
                 // Display left shortcut
+            } else {
+                visible = isPhoneVisible();
             }
         }
         mLeftAffordanceView.setVisibility(visible ? View.VISIBLE : View.GONE);


### PR DESCRIPTION
When telephony isn't available and the left icon has not yet been set to
a custom option, the left icon should be hidden.

This makes updateLeftAffordanceIcon and updateLeftButtonVisibility work
in a similar way to determine the icon visibility.

Change-Id: Ibb63ecef3c3cad73a19c04c85eccb93b423d5e80